### PR TITLE
Add FastAPI backend with SQLite storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,4 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 recordings/
+eyespy.db

--- a/eyespy/api/cameras.py
+++ b/eyespy/api/cameras.py
@@ -1,0 +1,56 @@
+from typing import List
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from .. import crud, schemas, models
+from ..database import SessionLocal, engine
+
+# Ensure tables are created
+models.Base.metadata.create_all(bind=engine)
+
+router = APIRouter(prefix="/cameras", tags=["cameras"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.get("/", response_model=List[schemas.Camera])
+def read_cameras(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    return crud.get_cameras(db, skip=skip, limit=limit)
+
+
+@router.post("/", response_model=schemas.Camera)
+def create_camera(camera: schemas.CameraCreate, db: Session = Depends(get_db)):
+    db_cam = crud.get_camera_by_name(db, name=camera.name)
+    if db_cam:
+        raise HTTPException(status_code=400, detail="Camera already exists")
+    return crud.create_camera(db, camera)
+
+
+@router.get("/{camera_id}", response_model=schemas.Camera)
+def read_camera(camera_id: int, db: Session = Depends(get_db)):
+    cam = crud.get_camera(db, camera_id)
+    if not cam:
+        raise HTTPException(status_code=404, detail="Camera not found")
+    return cam
+
+
+@router.put("/{camera_id}", response_model=schemas.Camera)
+def update_camera(camera_id: int, camera: schemas.CameraUpdate, db: Session = Depends(get_db)):
+    cam = crud.update_camera(db, camera_id, camera)
+    if not cam:
+        raise HTTPException(status_code=404, detail="Camera not found")
+    return cam
+
+
+@router.delete("/{camera_id}", response_model=schemas.Camera)
+def delete_camera(camera_id: int, db: Session = Depends(get_db)):
+    cam = crud.delete_camera(db, camera_id)
+    if not cam:
+        raise HTTPException(status_code=404, detail="Camera not found")
+    return cam

--- a/eyespy/crud.py
+++ b/eyespy/crud.py
@@ -1,0 +1,49 @@
+from sqlalchemy.orm import Session
+import os
+
+from . import models, schemas
+
+VIDEO_STORAGE_PATH = os.getenv("VIDEO_STORAGE_PATH", "recordings")
+
+
+def get_camera(db: Session, camera_id: int):
+    return db.query(models.Camera).filter(models.Camera.id == camera_id).first()
+
+
+def get_camera_by_name(db: Session, name: str):
+    return db.query(models.Camera).filter(models.Camera.name == name).first()
+
+
+def get_cameras(db: Session, skip: int = 0, limit: int = 100):
+    return db.query(models.Camera).offset(skip).limit(limit).all()
+
+
+def create_camera(db: Session, camera: schemas.CameraCreate):
+    data = camera.dict()
+    if not data.get("output"):
+        data["output"] = VIDEO_STORAGE_PATH
+    db_camera = models.Camera(**data)
+    db.add(db_camera)
+    db.commit()
+    db.refresh(db_camera)
+    return db_camera
+
+
+def update_camera(db: Session, camera_id: int, camera: schemas.CameraUpdate):
+    db_camera = get_camera(db, camera_id)
+    if not db_camera:
+        return None
+    for field, value in camera.dict(exclude_unset=True).items():
+        setattr(db_camera, field, value)
+    db.commit()
+    db.refresh(db_camera)
+    return db_camera
+
+
+def delete_camera(db: Session, camera_id: int):
+    db_camera = get_camera(db, camera_id)
+    if not db_camera:
+        return None
+    db.delete(db_camera)
+    db.commit()
+    return db_camera

--- a/eyespy/database.py
+++ b/eyespy/database.py
@@ -1,0 +1,16 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+from dotenv import load_dotenv
+import os
+
+# Load environment variables from a .env file if present
+load_dotenv()
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./eyespy.db")
+
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/eyespy/models.py
+++ b/eyespy/models.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, Integer, String, Float
+
+from .database import Base
+
+class Camera(Base):
+    __tablename__ = "cameras"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True, nullable=False)
+    url = Column(String, nullable=False)
+    output = Column(String, nullable=False)
+    fps = Column(Float, default=20.0)

--- a/eyespy/schemas.py
+++ b/eyespy/schemas.py
@@ -1,0 +1,23 @@
+from typing import Optional
+from pydantic import BaseModel
+
+class CameraBase(BaseModel):
+    name: str
+    url: str
+    output: Optional[str] = None
+    fps: float = 20.0
+
+class CameraCreate(CameraBase):
+    pass
+
+class CameraUpdate(BaseModel):
+    name: Optional[str] = None
+    url: Optional[str] = None
+    output: Optional[str] = None
+    fps: Optional[float] = None
+
+class Camera(CameraBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 opencv-python-headless
 PyYAML
+fastapi
+uvicorn
+SQLAlchemy
+python-dotenv


### PR DESCRIPTION
## Summary
- add FastAPI app that manages cameras through a SQLite DB
- use `python-dotenv` for `DATABASE_URL` and `VIDEO_STORAGE_PATH`
- create SQLAlchemy models and CRUD helpers
- expose camera management routes under `/cameras`
- update requirements

## Testing
- `pip install -r requirements.txt`
- `uvicorn main:app --port 8000 --workers 1 --reload` *(started and stopped)*

------
https://chatgpt.com/codex/tasks/task_e_684f689274cc83229567d6b2d35f9bc0