### PR TITLE
Stabilize worker imports and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,17 @@ exist.
 
 ## Running
 
-Run the aggregator with:
+Run the API server with:
 
 ```bash
 python main.py --config cameras.yaml
 ```
+To start the background worker that records camera streams run:
+
+```
+python -m eyespy.worker
+```
+
 
 The application will start recording each configured feed. Stop it with
 `Ctrl+C`. Footage is saved in the directories specified in the configuration

--- a/eyespy/worker.py
+++ b/eyespy/worker.py
@@ -5,12 +5,16 @@ import threading
 import time
 from typing import List
 
-# Allow running as a script by ensuring the package root is on the path
-if __package__ is None or __package__ == "":
-    from pathlib import Path
-    import sys
+# Ensure the project root is on the import path. This allows running the file
+# directly with ``python eyespy/worker.py`` as well as via ``python -m
+# eyespy.worker`` without having to continually tweak these imports in future
+# pull requests.
+from pathlib import Path
+import sys
 
-    sys.path.append(str(Path(__file__).resolve().parents[1]))
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 from eyespy.database import SessionLocal, engine
 from eyespy import crud, models


### PR DESCRIPTION
## Summary
- ensure project root is on sys.path for `eyespy.worker`
- document how to run the worker module

## Testing
- `python -m py_compile eyespy/*.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68537ab03fc48322bb017b817bb8cd5c